### PR TITLE
jth changes to `search-s3`

### DIFF
--- a/src/hyp3_srg/back_projection.py
+++ b/src/hyp3_srg/back_projection.py
@@ -174,7 +174,9 @@ def main():
     )
     parser.add_argument('granules', type=str.split, nargs='+', help='Level-0 S1 granule(s) to back-project.')
     args = parser.parse_args()
+
     args.granules = [item for sublist in args.granules for item in sublist]
+
     if args.bounds is not None:
         args.bounds = [float(item) for sublist in args.bounds for item in sublist]
         if len(args.bounds) != 4:

--- a/src/hyp3_srg/back_projection.py
+++ b/src/hyp3_srg/back_projection.py
@@ -149,6 +149,14 @@ def main():
     parser.add_argument('--earthdata-password', default=None, help="Password for NASA's EarthData")
     parser.add_argument('--bucket', help='AWS S3 bucket HyP3 for upload the final product(s)')
     parser.add_argument('--bucket-prefix', default='', help='Add a bucket prefix to product(s)')
+    parser.add_argument(
+        '--use-gslc-prefix',
+        action='store_true',
+        help=(
+            'Upload GSLC granules to a subprefix located within the bucket and prefix given by the'
+            ' --bucket and --bucket-prefix options'
+        )
+    )
     parser.add_argument('--gpu', default=False, action='store_true', help='Use the GPU-based version of the workflow.')
     parser.add_argument(
         '--bounds',
@@ -159,14 +167,16 @@ def main():
     )
     parser.add_argument('granules', type=str.split, nargs='+', help='Level-0 S1 granule(s) to back-project.')
     args = parser.parse_args()
+
     args.granules = [item for sublist in args.granules for item in sublist]
+
     if args.bounds is not None:
         args.bounds = [float(item) for sublist in args.bounds for item in sublist]
         if len(args.bounds) != 4:
             parser.error('Bounds must have exactly 4 values: [min lon, min lat, max lon, max lat] in EPSG:4326.')
 
-    # TODO: add a cli option to write granules to this sub-prefix
-    args.bucket_prefix += '/granules'
+    if args.use_gslc_prefix:
+        args.bucket_prefix += '/GSLC_granules'
 
     back_project(**args.__dict__)
 

--- a/src/hyp3_srg/back_projection.py
+++ b/src/hyp3_srg/back_projection.py
@@ -164,6 +164,10 @@ def main():
         args.bounds = [float(item) for sublist in args.bounds for item in sublist]
         if len(args.bounds) != 4:
             parser.error('Bounds must have exactly 4 values: [min lon, min lat, max lon, max lat] in EPSG:4326.')
+
+    # TODO: don't hard-code this
+    args.bucket_prefix += '/granules'
+
     back_project(**args.__dict__)
 
 

--- a/src/hyp3_srg/back_projection.py
+++ b/src/hyp3_srg/back_projection.py
@@ -165,7 +165,7 @@ def main():
         if len(args.bounds) != 4:
             parser.error('Bounds must have exactly 4 values: [min lon, min lat, max lon, max lat] in EPSG:4326.')
 
-    # TODO: don't hard-code this
+    # TODO: add a cli option to write granules to this sub-prefix
     args.bucket_prefix += '/granules'
 
     back_project(**args.__dict__)

--- a/src/hyp3_srg/time_series.py
+++ b/src/hyp3_srg/time_series.py
@@ -355,11 +355,14 @@ def main():
     )
     parser.add_argument('granules', type=str.split, nargs='*', default='', help='GSLC granules.')
     args = parser.parse_args()
+
     args.granules = [item for sublist in args.granules for item in sublist]
+
     if args.bounds is not None:
         args.bounds = [float(item) for sublist in args.bounds for item in sublist]
         if len(args.bounds) != 4:
             parser.error('Bounds must have exactly 4 values: [min lon, min lat, max lon, max lat] in EPSG:4326.')
+
     time_series(**args.__dict__)
 
 

--- a/src/hyp3_srg/time_series.py
+++ b/src/hyp3_srg/time_series.py
@@ -343,7 +343,7 @@ def main():
     parser.add_argument(
         '--gslc-bucket-prefix',
         default='',
-        help='GSLCs are found at bucket-prefix/gslc-bucket_prefix within bucket'
+        help='GSLCs are found at bucket-prefix/gslc-bucket-prefix within bucket'
     )
     parser.add_argument('granules', type=str.split, nargs='*', default='', help='GSLC granules.')
     args = parser.parse_args()

--- a/src/hyp3_srg/time_series.py
+++ b/src/hyp3_srg/time_series.py
@@ -342,7 +342,7 @@ def main():
     )
     parser.add_argument('--bucket', help='AWS S3 bucket HyP3 for upload the final product(s)')
     parser.add_argument('--bucket-prefix', default='', help='Add a bucket prefix to product(s)')
-    parser.add_argument('--use-granules-from-s3', type=bool, action='store_true')
+    parser.add_argument('--use-granules-from-s3', action='store_true')
     parser.add_argument('granules', type=str.split, nargs='*', default='', help='GSLC granules.')
     args = parser.parse_args()
     args.granules = [item for sublist in args.granules for item in sublist]

--- a/src/hyp3_srg/time_series.py
+++ b/src/hyp3_srg/time_series.py
@@ -337,15 +337,23 @@ def main():
         S1A_IW_RAW__0SDV_20231229T134404_20231229T134436_051870_064437_5F38.geo
     """
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument(
-        '--bounds', default=None, type=float, nargs=4, help='Bounding box that was used to generate the GSLCs'
-    )
     parser.add_argument('--bucket', help='AWS S3 bucket HyP3 for upload the final product(s)')
     parser.add_argument('--bucket-prefix', default='', help='Add a bucket prefix to product(s)')
+    parser.add_argument(
+        '--bounds',
+        default=None,
+        type=str.split,
+        nargs='+',
+        help='DEM extent bbox in EPSG:4326: [min_lon, min_lat, max_lon, max_lat].'
+    )
     parser.add_argument('--use-granules-from-s3', action='store_true')
     parser.add_argument('granules', type=str.split, nargs='*', default='', help='GSLC granules.')
     args = parser.parse_args()
     args.granules = [item for sublist in args.granules for item in sublist]
+    if args.bounds is not None:
+        args.bounds = [float(item) for sublist in args.bounds for item in sublist]
+        if len(args.bounds) != 4:
+            parser.error('Bounds must have exactly 4 values: [min lon, min lat, max lon, max lat] in EPSG:4326.')
     time_series(**args.__dict__)
 
 

--- a/src/hyp3_srg/time_series.py
+++ b/src/hyp3_srg/time_series.py
@@ -74,26 +74,26 @@ def load_products(uris: Iterable[str], overwrite: bool = False):
     return granule_names
 
 
-def get_size_from_dem(dem_file: str) -> tuple[int]:
+def get_size_from_dem(dem_path: str) -> tuple[int, int]:
     """Get the length and width from a .rsc DEM file
 
     Args:
-        dem_file: path to the .rsc dem file.
+        dem_path: path to the .rsc dem file.
 
     Returns:
         dem_width, dem_length: tuple containing the dem width and dem length
     """
-    with open(dem_file) as dem:
-        width_line = dem.readline()
+    with open(dem_path) as dem_file:
+        width_line = dem_file.readline()
         dem_width = width_line.split()[1]
-        length_line = dem.readline()
+        length_line = dem_file.readline()
         dem_length = length_line.split()[1]
 
     return int(dem_width), int(dem_length)
 
 
 def generate_wrapped_interferograms(
-    looks: tuple[int], baselines: tuple[int], dem_shape: tuple[int], work_dir: Path
+    looks: tuple[int, int], baselines: tuple[int, int], dem_shape: tuple[int, int], work_dir: Path
 ) -> None:
     """Generates wrapped interferograms from GSLCs
 
@@ -113,7 +113,7 @@ def generate_wrapped_interferograms(
     utils.call_stanford_module('sentinel/ps_sbas_igrams.py', args=sbas_args, work_dir=work_dir)
 
 
-def unwrap_interferograms(dem_shape: tuple[int], unw_shape: tuple[int], work_dir: Path) -> None:
+def unwrap_interferograms(dem_shape: tuple[int, int], unw_shape: tuple[int, int], work_dir: Path) -> None:
     """Unwraps wrapped interferograms in parallel
 
     Args:
@@ -130,7 +130,7 @@ def unwrap_interferograms(dem_shape: tuple[int], unw_shape: tuple[int], work_dir
 
 
 def compute_sbas_velocity_solution(
-    threshold: float, do_tropo_correction: bool, unw_shape: tuple[int], work_dir: Path
+    threshold: float, do_tropo_correction: bool, unw_shape: tuple[int, int], work_dir: Path
 ) -> None:
     """Computes the sbas velocity solution from the unwrapped interferograms
 
@@ -153,11 +153,9 @@ def compute_sbas_velocity_solution(
         tropo_correct_args = ['unwlist', unw_width, unw_length]
         utils.call_stanford_module('int/tropocorrect.py', args=tropo_correct_args, work_dir=work_dir)
 
-    num_unw_files = 0
     with open(work_dir / 'unwlist', 'r') as unw_list:
         num_unw_files = len(unw_list.readlines())
 
-    num_slcs = 0
     with open(work_dir / 'geolist', 'r') as slc_list:
         num_slcs = len(slc_list.readlines())
 
@@ -166,8 +164,8 @@ def compute_sbas_velocity_solution(
 
 
 def create_time_series(
-    looks: tuple[int] = (10, 10),
-    baselines: tuple[int] = (1000, 1000),
+    looks: tuple[int, int] = (10, 10),
+    baselines: tuple[int, int] = (1000, 1000),
     threshold: float = 0.5,
     do_tropo_correction: bool = True,
     work_dir: Path | None = None,
@@ -184,7 +182,7 @@ def create_time_series(
     dem_shape = get_size_from_dem('elevation.dem.rsc')
     generate_wrapped_interferograms(looks=looks, baselines=baselines, dem_shape=dem_shape, work_dir=work_dir)
 
-    unw_shape = get_size_from_dem(work_dir / 'dem.rsc')
+    unw_shape = get_size_from_dem(str(work_dir / 'dem.rsc'))
     unwrap_interferograms(dem_shape=dem_shape, unw_shape=unw_shape, work_dir=work_dir)
 
     compute_sbas_velocity_solution(
@@ -199,7 +197,7 @@ def create_time_series_product_name(
     """Create a product name for the given granules.
 
     Args:
-        granules: list of the granule names
+        granule_names: list of the granule names
         bounds: bounding box that was used to generate the GSLCs
 
     Returns:
@@ -276,7 +274,7 @@ def package_time_series(
         'velocity',
     ]
     [shutil.copy(sbas_dir / f, product_path / f) for f in to_keep]
-    shutil.make_archive(product_path, 'zip', product_path)
+    shutil.make_archive(str(product_path), 'zip', product_path)
     return zip_path
 
 
@@ -285,7 +283,6 @@ def time_series(
     bounds: list[float],
     bucket: str = None,
     bucket_prefix: str = '',
-    gslc_bucket: str = None,
     gslc_bucket_prefix: str = '',
     work_dir: Optional[Path] = None,
 ) -> None:
@@ -296,8 +293,7 @@ def time_series(
         bounds: bounding box that was used to generate the GSLCs
         bucket: AWS S3 bucket for uploading the final product(s)
         bucket_prefix: Add a bucket prefix to the product(s)
-        gslc_bucket: AWS S3 bucket containing GSLCs for time-series processing
-        gslc_bucket_prefix: Path to GSLCs within gslc_bucket.
+        gslc_bucket_prefix: GSLCs are found at bucket_prefix/gslc_bucket_prefix within bucket
         work_dir: Working directory for processing
     """
     if work_dir is None:
@@ -306,13 +302,14 @@ def time_series(
     if not sbas_dir.exists():
         mkdir(sbas_dir)
 
-    if granules and gslc_bucket:
-        raise ValueError('One of a list of granules or a s3 bucket must be provided, but got both.')
+    if granules and gslc_bucket_prefix:
+        raise ValueError('One of a list of granules or a GSLC S3 bucket prefix must be provided, but got both.')
 
-    if granules == []:
-        if gslc_bucket is None:
-            raise ValueError('Either a list of granules or a s3 bucket must be provided, but got neither.')
-        granules = get_gslc_uris_from_s3(gslc_bucket, gslc_bucket_prefix)
+    if not granules:
+        if gslc_bucket_prefix is None:
+            raise ValueError('Either a list of granules or a GSLC S3 bucket prefix must be provided, but got neither.')
+        # TODO: check that bucket and bucket_prefix were passed
+        granules = get_gslc_uris_from_s3(bucket, f'{bucket_prefix}/{gslc_bucket_prefix}')
 
     granule_names = load_products(granules)
     dem_path = dem.download_dem_for_srg(bounds, work_dir)
@@ -343,8 +340,11 @@ def main():
     )
     parser.add_argument('--bucket', help='AWS S3 bucket HyP3 for upload the final product(s)')
     parser.add_argument('--bucket-prefix', default='', help='Add a bucket prefix to product(s)')
-    parser.add_argument('--gslc-bucket', help='AWS S3 bucket containing GSLCs to process')
-    parser.add_argument('--gslc-bucket-prefix', default='', help='Path to GSLCs within gslc-bucket.')
+    parser.add_argument(
+        '--gslc-bucket-prefix',
+        default='',
+        help='GSLCs are found at bucket-prefix/gslc-bucket_prefix within bucket'
+    )
     parser.add_argument('granules', type=str.split, nargs='*', default='', help='GSLC granules.')
     args = parser.parse_args()
     args.granules = [item for sublist in args.granules for item in sublist]

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -39,7 +39,7 @@ def test_get_size_from_dem(tmp_path):
     rsc_path = tmp_path / 'elevation.dem.rsc'
     with open(rsc_path, 'w') as rsc_file:
         rsc_file.write(rsc_content.strip())
-    dem_width, dem_height = time_series.get_size_from_dem(dem_file=rsc_path)
+    dem_width, dem_height = time_series.get_size_from_dem(dem_path=rsc_path)
     assert dem_width, dem_height == (1235, 873)
 
 


### PR DESCRIPTION
- GSLCs can now be uploaded to / downloaded from a special `/GSLC_granules` subprefix under the job id prefix
    - Adds a `--use-gslc-prefix` option to `back_projection.py` for uploading the GSLCs to the subprefix
    - Replaces `--gslc-bucket` and `--gslc-bucket-prefix` with a `--use-gslc-prefix` option in `time_series.py`
- Fixes `--bounds` parsing in `time_series.py`
- Addresses several PyCharm linter warnings